### PR TITLE
BAU: Add request denied location block

### DIFF
--- a/src/files/sites.nginx
+++ b/src/files/sites.nginx
@@ -29,7 +29,15 @@ server {
 
   # Health check url
   location /healthcheck {
+    set $http_x_request_id $request_id;
     return 200 'OK';
+    add_header Content-Type text/plain;
+  }
+
+  # Request denied
+  location /request-denied {
+    set $http_x_request_id $request_id;
+    return 400 'DENIED';
     add_header Content-Type text/plain;
   }
 


### PR DESCRIPTION
- adds request ids to /healthcheck and to /request-denied
- returns plain 400 instead of trying to look up html page that doesn't exist

solo @tlwr