### PR TITLE
PP-4375 Add rules to allow stripe notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -20,6 +20,8 @@
 #      |                 | reason                                      #
 #      |                 | URL /v1/api/notifications/epdq              #
 #      |                 | cn                                          #
+#      |                 | URL /v1/api/notifications/stripe            #
+#      |                 | seller_message                              #
 # -------------------------------------------------------------------- #
 # 1011 | )               | URL /v1/api/notifications/smartpay          #
 #      |                 | reason                                      #
@@ -28,11 +30,24 @@
 # -------------------------------------------------------------------- #
 # 1013 | '               | URL /v1/api/notifications/epdq              #
 #      |                 | cn                                          #
+#      |                 | URL /v1/api/notifications/stripe            #
+#      |                 | failure_message                             #
 # -------------------------------------------------------------------- #
 # 1015 | ,               | URL /v1/api/notifications/epdq              #
 #      |                 | cn                                          #
+#      |                 | URL /v1/api/notifications/stripe            #
+#      |                 | line                                        #
+# -------------------------------------------------------------------- #
+# 1009 | =               | URL /v1/api/notifications/stripe            #
+#      |                 | return_url                                  #
 # -------------------------------------------------------------------- #
 # 1101 | https://        | URL /v1/api/notifications/stripe            #
+#      |                 | return_url, url                             #
+# -------------------------------------------------------------------- #
+# 1100 | http://         | URL /v1/api/notifications/stripe            #
+#      |                 | return_url                                  #
+# -------------------------------------------------------------------- #
+# 1314 | `               | URL /v1/api/notifications/stripe            #
 #      |                 | return_url                                  #
 # -------------------------------------------------------------------- #
 
@@ -56,5 +71,8 @@ BasicRule wl:1010,1011 "mz:$URL:/v1/api/notifications/smartpay|$BODY_VAR_X:^reas
 BasicRule wl:1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";
 
 #STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
-BasicRule wl:1101 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^return_url$";
-BasicRule wl:1009,1101 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^url$";
+BasicRule wl:1009,1101,1100 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^return_url$";
+BasicRule wl:1009,1101,1100 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^url$";
+BasicRule wl:1010,1314 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^seller_message$";
+BasicRule wl:1015 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^line";
+BasicRule wl:1013 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^failure_message$";


### PR DESCRIPTION
By analysing our logs we have found rules that were being triggered by
legitimate stripe notifications. This commit relaxes the specific rules
for the specific attributes as per that analysis.

See https://payments-platform.atlassian.net/browse/PP-4375 for
details.