### PR TITLE
PP-4757 NAXSI: rules for all *url properties for Stripe notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -24,8 +24,7 @@ BasicRule wl:1010,1011 "mz:$URL:/v1/api/notifications/smartpay|$BODY_VAR_X:^reas
 BasicRule wl:1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";
 
 # STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
-BasicRule wl:1009,1101,1100 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^return_url$";
-BasicRule wl:1009,1101,1100 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^url$";
+BasicRule wl:1000,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix
 BasicRule wl:1010,1314 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^seller_message$";
 BasicRule wl:1015 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^line";
 BasicRule wl:1013,1015 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^name$";


### PR DESCRIPTION
## WHAT

- For consistency, apply the same rules as in Public API `return_url` (related PR https://github.com/alphagov/pay-infra/pull/1936):

Cross-referencing with https://github.com/nbs-system/naxsi/blob/master/naxsi_config/naxsi_core.rules we're whitelisting the following:

1000: sql keywords
1002: 0x, possible hex encoding
1003: mysql comment (/*)
1004: mysql comment (*/)
1005: mysql keyword (|)
1006: mysql keyword (&&)
1007: mysql comment (--)
1008: semicolon
1009: equal sign in var, probable sql/xss
1010: open parenthesis
1011: close parenthesis
1013: simple quote
1015: comma
1016: mysql comment (#)
1017: double arobase (@@)
1100: http://
1101: https://
1200: double dot
1205: backslash
1302: html open tag
1303: html close tag
1310: open square backet ([)
1311: close square bracket (])
1312: tilde (~) character
1314: grave accent (`)
1315: double encoding
1400: utf7/8 encoding
1401: M$ encoding

- Make the rule generic with all of the `*url` properties, including `url`, `return_url`, `receipt_url`

with @heathd