### PR TITLE
PP-4936 Whitelist rules for body of Smartpay notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -17,8 +17,8 @@ BasicRule wl:1205 "mz:BODY";
 # SQL key words, 0x, \\ in cookie
 BasicRule wl:1000,1002,1007 "mz:$HEADERS_VAR:cookie";
 
-# SMARTPAY NOTIFICATIONS - reason field in smartpay notifications can contain ()
-BasicRule wl:1010,1011 "mz:$URL:/v1/api/notifications/smartpay|$BODY_VAR_X:^reason$";
+# SMARTPAY NOTIFICATIONS - whitelist rules we have blocked on for all body fields
+BasicRule wl:1009,1010,1011,1013 "mz:$URL:/v1/api/notifications/smartpay|BODY";
 
 # EPDQ NOTIFICATIONS - cn field in epdq notifications can contain () and '
 BasicRule wl:1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";


### PR DESCRIPTION
Whitelist the following rules for the body of a Smartpay notification.
1009 - "="
1010 - "("
1011 - ")"
1012 - "\'"

Smartpay notifications come from a trusted URL and we do secret
validation on incoming requests to ensure this. Therefore, if the body
is well-formed JSON - which is enforced by NAXSI the risk is very low
of having any malicious content in the notification.

It appears that we are receiving Smartpay notifications containing
fields that we weren't previously receiving which is why we are having
to loosen the NAXSI rules.

with @heathd