### PR TITLE
PP-4963 Whitelist rules for Stripe notification body

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -25,7 +25,5 @@ BasicRule wl:1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X
 
 # STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
 BasicRule wl:1000,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix
-BasicRule wl:1010,1314 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^seller_message$";
-BasicRule wl:1013,1015 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^line";
-BasicRule wl:1013,1015 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^name$";
-BasicRule wl:1013 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^failure_message$";
+# Whitelist rules for common characters for all body fields
+BasicRule wl:1010,1011,1013,1015,1314 "mz:$URL:/v1/api/notifications/stripe|BODY";


### PR DESCRIPTION
Whitelist the following rules for the body of a Stripe notification:
1010 - "("
1011 - ")"
1013 - "\'"
1015 - ","
1314 - "`"

Stripe notifications come from a trusted URL and we do secret
validation on incoming requests to ensure this. Therefore, if the body
is well-formed JSON, which is enforced by NAXSI, the risk is very low
of having any malicious content in the notification.