### PR TITLE
PP-4748 Upgrade naxsi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM govukpay/alpine:latest-master
 
 ENV NGINX_VERSION=1.13.3 \
-    NAXSI_VERSION=0.55.3
+    NAXSI_VERSION=0.56
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
         libxslt-dev \
         gd-dev \
         geoip-dev \
-    && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
-    && curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
+    && curl --fail -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
+    && curl --fail -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc -o nginx.tar.gz.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && found=''; \
     for server in \
@@ -42,19 +42,18 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && pkill -9 gpg-agent && pkill -9 dirmngr \
     && echo 'Removing $GNUPGHOME and nginx fingerprint' \
     && rm -rf "$GNUPGHOME" nginx.tar.gz.asc \
-    && curl -fSL https://github.com/nbs-system/naxsi/archive/$NAXSI_VERSION.tar.gz -o naxsi.tar.gz \
-    && mkdir -p /usr/src \
-    && tar -zxC /usr/src -f nginx.tar.gz \
+    && curl --fail -fSL https://github.com/nbs-system/naxsi/archive/$NAXSI_VERSION.tar.gz -o naxsi.tar.gz \
+    && mkdir -p /usr/src/nginx /usr/src/naxsi \
+    && tar -zxC /usr/src/nginx --strip-components 1 -f nginx.tar.gz \
     && rm nginx.tar.gz \
-    && tar -zxC /usr/src -f naxsi.tar.gz \
-    && rm naxsi.tar.gz
-
-RUN CONFIG="\
+    && tar -zxC /usr/src/naxsi --strip-components 1 -f naxsi.tar.gz \
+    && rm naxsi.tar.gz \
+    && CONFIG="\
       --prefix=/etc/nginx \
       --sbin-path=/usr/sbin/nginx \
       --modules-path=/usr/lib/nginx/modules \
       --conf-path=/etc/nginx/nginx.conf \
-      --add-module=../naxsi-$NAXSI_VERSION/naxsi_src/ \
+      --add-module=../naxsi/naxsi_src/ \
       --error-log-path=/var/log/nginx/error.log \
       --http-log-path=/var/log/nginx/access.log \
       --pid-path=/var/run/nginx.pid \
@@ -94,7 +93,7 @@ RUN CONFIG="\
       --with-file-aio \
       --with-ipv6 \
       --with-http_v2_module" \
-    && cd /usr/src/nginx-$NGINX_VERSION \
+    && cd /usr/src/nginx \
     && ./configure $CONFIG --with-debug \
     && make -j$(getconf _NPROCESSORS_ONLN) \
     && mv objs/nginx objs/nginx-debug \
@@ -115,9 +114,11 @@ RUN CONFIG="\
     && ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
     && strip /usr/sbin/nginx* \
     && strip /usr/lib/nginx/modules/*.so \
-    && rm -rf /usr/src/nginx-$NGINX_VERSION
+    && rm -rf /usr/src/nginx \
+    && apk del .build-deps
 
-RUN openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048 \
+RUN apk add openssl \
+    && openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048 \
     # forward request and error logs to docker log collector
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log


### PR DESCRIPTION
Upgrade our naxsi version from 0.55.3 to 0.56

At the same time, clean up the docker build by removing build dependencies, shrinking the container from ~200MB to ~15MB