### PR TITLE
PP-4748: Avoid uninstalling pcre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN addgroup -S nginx \
     && adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+    && apk add pcre \
     && apk add --no-cache --virtual .build-deps \
         gcc \
         libc-dev \


### PR DESCRIPTION
naxsi depends on pcre, which was previously installed as part of the build
dependencies. Now that we're removing build dependencies from the image, this
breaks naxsi with the following errors:

Error loading shared library libpcre.so.1: No such file or directory (needed by /usr/sbin/nginx)
Error relocating /usr/sbin/nginx: pcre_exec: symbol not found
Error relocating /usr/sbin/nginx: pcre_fullinfo: symbol not found
Error relocating /usr/sbin/nginx: pcre_config: symbol not found
Error relocating /usr/sbin/nginx: pcre_compile: symbol not found
Error relocating /usr/sbin/nginx: pcre_free_study: symbol not found
Error relocating /usr/sbin/nginx: pcre_study: symbol not found
Error relocating /usr/sbin/nginx: pcre_malloc: symbol not found
Error relocating /usr/sbin/nginx: pcre_free: symbol not found

Install pcre separately to the build dependencies so that it doesn't get
removed.