### PR TITLE
RED-45: Reference base Docker images via digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM govukpay/alpine:latest-master
+# alpine:3.9
+FROM alpine@sha256:769fddc7cc2f0a1c35abb2f91432e8beecf83916c421420e6a6da9f8975464b6
 
 ENV NGINX_VERSION=1.13.3 \
     NAXSI_VERSION=0.56


### PR DESCRIPTION
So that we can have confidence our base images aren't being changed without our
knowledge, reference them by digest instead of tag (as tags are not immutable).

Also, add a comment detailing the tag the digest corresponds to.