### PR TITLE
PP-3717 Whitelist rule for GoCardless webhooks

### DIFF
--- a/src/files/naxsi_dd_connector_whitelist.rules
+++ b/src/files/naxsi_dd_connector_whitelist.rules
@@ -6,3 +6,6 @@
 ##################################################################################
 
 BasicRule wl:1013,1015 "mz:$URL:/v1/webhooks/gocardless|$BODY_VAR:description";
+
+# can get 0x in GoCardless resource IDs
+BasicRule wl:1002 "mz:$URL:/v1/webhooks/gocardless|BODY";


### PR DESCRIPTION
We're blocking on rule 1002, as resource IDs in events can contain the string "0x". Whitelisting for all body fields as their are numerous different ids events could contain.