### PR TITLE
PP-5655 White list naxsi rule 1002 for stripe notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -25,5 +25,7 @@ BasicRule wl:1010,1011,1013,1015,1314 "mz:$URL:/v1/api/notifications/epdq|$BODY_
 
 # STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
 BasicRule wl:1000,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix
+BasicRule wl:1002 "mz:$URL:/v1/api/notifications/stripe|BODY"; # do not apply possible hex encoding check to any field
+
 # Whitelist rules for common characters for all body fields
 BasicRule wl:1000,1005,1008,1010,1011,1013,1015,1016,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/stripe|BODY";


### PR DESCRIPTION
Do not apply rule 1002 'possible hex encoding' check to any field within
the notification from Stripe. There are many fields which have the potential
to include '0x' and since Stripe is a trusted party it seems practical to whitelist
this rule for the entire body rather than specific fields which may
change. We apply the same white listing of rule 1002 for Direct Debit
Connector Go Cardless webhook.
    
Associated Zendesk ticket is: 3807008