### PR TITLE
PP-5843 Whitelist comma in body for smartpay notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -18,7 +18,7 @@ BasicRule wl:1205 "mz:BODY";
 BasicRule wl:1000,1002,1007 "mz:$HEADERS_VAR:cookie";
 
 # SMARTPAY NOTIFICATIONS - whitelist rules we have blocked on for all body fields
-BasicRule wl:1001,1005,1009,1010,1011,1013 "mz:$URL:/v1/api/notifications/smartpay|BODY";
+BasicRule wl:1001,1005,1009,1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/smartpay|BODY";
 
 # EPDQ NOTIFICATIONS - cn field in epdq notifications can contain () and '
 BasicRule wl:1010,1011,1013,1015,1314 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";


### PR DESCRIPTION
Rule 1015 is a comma

As notifications come from a whitelisted IP, we generally unblock rules
we're blocking on if it seems sensible that the notification could
contain the character we’re blocking on. In this case it does as the
field is 'operations' which suggests the value could be a comma
separated list.