### PR TITLE
PP-5876: Update container to run on PaaS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,8 @@ RUN ["apk", "--no-cache", "--repository=http://dl-cdn.alpinelinux.org/alpine/edg
 
 RUN ["install", "-d", "/etc/nginx/ssl"]
 
-RUN apk add openssl \
-    && openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048 \
-    # forward request and error logs to docker log collector
-    && ln -sf /dev/stdout /var/log/nginx/access.log \
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
 RUN ["install", "-d", "/app"]
@@ -21,8 +19,6 @@ ADD src/files/authorized_ip /etc/nginx/
 ADD src/files/*.conf /etc/nginx/conf.d/
 ADD src/files/sites.nginx /etc/nginx/conf.d/notifications.conf
 COPY src/files/nginx_conf /etc/nginx/nginx.conf
-
-EXPOSE 443
 
 WORKDIR /app
 

--- a/src/docker-startup.sh
+++ b/src/docker-startup.sh
@@ -8,10 +8,13 @@ NGINX_CONFIG="/etc/nginx/nginx.conf"
 DD_CONNECTOR_URL=${DD_CONNECTOR_URL:-"https://localhost:5000"}
 CONNECTOR_URL=${CONNECTOR_URL:-"https://localhost:5001"}
 DNS_RESOLVER_IP=${DNS_RESOLVER_IP:-"169.254.0.2"}
+PORT=${PORT:-"8080"}
 
 sed -i "s,DD_CONNECTOR_URL,${DD_CONNECTOR_URL},g" $SITE_CONFIG
 sed -i "s,CONNECTOR_URL,${CONNECTOR_URL},g" $SITE_CONFIG
 sed -i "s,DNS_RESOLVER_IP,${DNS_RESOLVER_IP},g" $SITE_CONFIG
+sed -i "s,PORT,${PORT},g" $SITE_CONFIG
 sed -i "s,listen \[::\]:80 default_server;,,g" "/etc/nginx/conf.d/default.conf"
+
 
 exec nginx -g "daemon off;"

--- a/src/docker-startup.sh
+++ b/src/docker-startup.sh
@@ -7,18 +7,11 @@ NGINX_CONFIG="/etc/nginx/nginx.conf"
 
 DD_CONNECTOR_URL=${DD_CONNECTOR_URL:-"https://localhost:5000"}
 CONNECTOR_URL=${CONNECTOR_URL:-"https://localhost:5001"}
+DNS_RESOLVER_IP=${DNS_RESOLVER_IP:-"169.254.0.2"}
 
 sed -i "s,DD_CONNECTOR_URL,${DD_CONNECTOR_URL},g" $SITE_CONFIG
 sed -i "s,CONNECTOR_URL,${CONNECTOR_URL},g" $SITE_CONFIG
-
-# Generate a selfsigned key and certificate if we don't have one
-if [ ! -f /etc/keys/crt ]; then
-  dir=`mktemp -d`
-  openssl req -x509 -days 1000 -newkey rsa:2048 -nodes -subj '/CN=notifications' -keyout "$dir/key" -out "$dir/crt"
-  mkdir -p /etc/keys
-  install -m 0600 -o nginx -g nginx "$dir/key" /etc/keys/key
-  install -m 0644 -o nginx -g nginx "$dir/crt" /etc/keys/crt
-  rm -rf "$dir"
-fi
+sed -i "s,DNS_RESOLVER_IP,${DNS_RESOLVER_IP},g" $SITE_CONFIG
+sed -i "s,listen \[::\]:80 default_server;,,g" "/etc/nginx/conf.d/default.conf"
 
 exec nginx -g "daemon off;"

--- a/src/files/sites.nginx
+++ b/src/files/sites.nginx
@@ -1,5 +1,5 @@
 server {
-  listen 8080;
+  listen PORT;
 
   resolver DNS_RESOLVER_IP;
 

--- a/src/files/sites.nginx
+++ b/src/files/sites.nginx
@@ -1,6 +1,8 @@
 server {
   listen 8080;
 
+  resolver DNS_RESOLVER_IP;
+
   # Use variable to force dynamic DNS resolution as per
   # https://tenzer.dk/nginx-with-dynamic-upstreams/.
   # Without this nginx caches DNS lookups on startup and never updates

--- a/src/files/sites.nginx
+++ b/src/files/sites.nginx
@@ -1,8 +1,5 @@
 server {
-  listen 443 ssl;
-
-  # This should be the VPC network range +2
-  resolver 172.18.0.2;
+  listen 8080;
 
   # Use variable to force dynamic DNS resolution as per
   # https://tenzer.dk/nginx-with-dynamic-upstreams/.
@@ -16,16 +13,6 @@ server {
   server_name notifications;
   client_body_buffer_size 5m;
   client_max_body_size 5m;
-
-  ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256;
-  ssl_prefer_server_ciphers on;
-  ssl_protocols TLSv1.2;
-  ssl_session_timeout 10m;
-  ssl_dhparam /etc/nginx/ssl/dhparam.pem;
-  ssl_session_cache shared:SSL:50m;
-  ssl_session_tickets off;
-  ssl_certificate /etc/keys/crt;
-  ssl_certificate_key /etc/keys/key;
 
   # Health check url
   location /healthcheck {


### PR DESCRIPTION
* Removes self-signed SSL cert (no longer required)
* Removes ip6 listener on startup (crashes on PaaS)
* Allow configurable DNS resolver IP & listener port