### PR TITLE
BAU Whitelist rule 1000 for action field in GoCardless webhooks

### DIFF
--- a/src/files/naxsi_dd_connector_whitelist.rules
+++ b/src/files/naxsi_dd_connector_whitelist.rules
@@ -6,6 +6,7 @@
 ##################################################################################
 
 BasicRule wl:1013,1015 "mz:$URL:/v1/webhooks/gocardless|$BODY_VAR:description";
+BasicRule wl:1000 "mz:$URL:/v1/webhooks/gocardless|$BODY_VAR:action";
 
 # can get 0x in GoCardless resource IDs
 BasicRule wl:1002 "mz:$URL:/v1/webhooks/gocardless|BODY";


### PR DESCRIPTION
We received the following NAXSI block alert
&uri=/v1/webhooks/gocardless&learning=0&vers=0.56&total_processed=296&total_blocked=1&block=1&cscore0=$SQL&score0=8&zone0=BODY&id0=1000&var_name0=action&zone1=BODY&id1=1000&var_name1=cause

Rule 1000 is sql keyword.
The field "action" in a webhook can contain the action "updated" which
is what NAXSI appears to be blocking on here.