### PR TITLE
Allow NAXSI 1000 for cause and description in GC notifications

### DIFF
--- a/src/files/naxsi_dd_connector_whitelist.rules
+++ b/src/files/naxsi_dd_connector_whitelist.rules
@@ -5,8 +5,9 @@
 # https://github.com/nbs-system/naxsi/wiki                                       #
 ##################################################################################
 
-BasicRule wl:1013,1015 "mz:$URL:/v1/webhooks/gocardless|$BODY_VAR:description";
+BasicRule wl:1000,1013,1015 "mz:$URL:/v1/webhooks/gocardless|$BODY_VAR:description";
 BasicRule wl:1000 "mz:$URL:/v1/webhooks/gocardless|$BODY_VAR:action";
+BasicRule wl:1000 "mz:$URL:/v1/webhooks/gocardless|$BODY_VAR:cause";
 
 # can get 0x in GoCardless resource IDs
 BasicRule wl:1002 "mz:$URL:/v1/webhooks/gocardless|BODY";


### PR DESCRIPTION
NAXSI’s is blocking GoCardless notifications because of rule 1000, which is SQL keywords, triggering for the `action` and `cause` fields.

It’s probably the word “updated” (like SQL’s `UPDATE`) appearing in the notifications in those fields.

The action field was whitelisted in https://github.com/alphagov/pay-notifications/pull/34. Whitelist `cause` as well and — for good measure — `description`.