### PR TITLE
BAU - Whitelist rules for description field in Stripe notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -29,3 +29,6 @@ BasicRule wl:1002 "mz:$URL:/v1/api/notifications/stripe|BODY"; # do not apply po
 
 # Whitelist rules for common characters for all body fields
 BasicRule wl:1000,1005,1008,1010,1011,1013,1015,1016,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/stripe|BODY";
+
+# Whitelist all characters we allow for descriptions in public-api for description field
+BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^description";


### PR DESCRIPTION
We send the payment description to Stripe and they send it back in
webhooks.

We were blocking a webhook because the description contained ".." (rule
1200).

Whitelist all rules we allow for the description in payment creation
as the description could potentially violate any of these.