### PR TITLE
BAU Whitelist rule 1008 for smartpay notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -18,7 +18,7 @@ BasicRule wl:1205 "mz:BODY";
 BasicRule wl:1000,1002,1007 "mz:$HEADERS_VAR:cookie";
 
 # SMARTPAY NOTIFICATIONS - whitelist rules we have blocked on for all body fields
-BasicRule wl:1001,1005,1009,1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/smartpay|BODY";
+BasicRule wl:1001,1005,1008,1009,1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/smartpay|BODY";
 
 # EPDQ NOTIFICATIONS - cn field in epdq notifications can contain () and '
 BasicRule wl:1008,1010,1011,1013,1015,1314 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";


### PR DESCRIPTION
We were blocking on rule 1008 (semicolon) for the merchantreference field.

For smartpay, we whitelist rules for all body fields as we don't really know what we're getting, so long as it seems sensible to.