### PR TITLE
Zen desk 3954915 Whitelist smartpay and stripe notifications

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -18,13 +18,13 @@ BasicRule wl:1205 "mz:BODY";
 BasicRule wl:1000,1002,1007 "mz:$HEADERS_VAR:cookie";
 
 # SMARTPAY NOTIFICATIONS - whitelist rules we have blocked on for all body fields
-BasicRule wl:1001,1005,1008,1009,1010,1011,1013,1015 "mz:$URL:/v1/api/notifications/smartpay|BODY";
+BasicRule wl:1000,1001,1005,1007,1008,1009,1010,1011,1013,1015,1016,1200,1205,1310,1311,1312,1314,"mz:$URL:/v1/api/notifications/smartpay|BODY";
 
 # EPDQ NOTIFICATIONS - cn field in epdq notifications can contain () and '
 BasicRule wl:1008,1010,1011,1013,1015,1314 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";
 
 # STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
-BasicRule wl:1000,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix
+BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix
 BasicRule wl:1002 "mz:$URL:/v1/api/notifications/stripe|BODY"; # do not apply possible hex encoding check to any field
 
 # Whitelist rules for common characters for all body fields


### PR DESCRIPTION
Whitelist rule 1000 for smartpay which restricted sql keywords and was
blocking the `authcode` in the body.

Whitelist rules for body of smartpay to align with address fields in frontend.

Whitelist rule 1001 for stripe which restricted double quotes and was
blocking on the `line1` field in the body.

zendesk ticket https://govuk.zendesk.com/agent/tickets/3954915