### PR TITLE
Zendesk 4070651 Update ePDQ notifications cn whitelist

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -20,8 +20,8 @@ BasicRule wl:1000,1002,1007 "mz:$HEADERS_VAR:cookie";
 # SMARTPAY NOTIFICATIONS - whitelist rules we have blocked on for all body fields
 BasicRule wl:1000,1001,1005,1007,1008,1009,1010,1011,1013,1015,1016,1200,1205,1310,1311,1312,1314,"mz:$URL:/v1/api/notifications/smartpay|BODY";
 
-# EPDQ NOTIFICATIONS - cn field in epdq notifications can contain () and '
-BasicRule wl:1008,1010,1011,1013,1015,1314 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";
+# EPDQ NOTIFICATIONS - cn field in ePDQ notifications is cardholder name - match what we allow in frontend
+BasicRule wl:1000,1001,1005,1008,1009,1010,1011,1013,1015,1016,1200,1205,1302,1303,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";
 
 # STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
 BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix


### PR DESCRIPTION
The `cn` parameter in ePDQ notifications contains the cardholder name so we want to allow the same things we allow for the `cardholdername` field in frontend.