### PR TITLE
PP-6176: Update Alpine to 3.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998
+FROM alpine:3.12.0@sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65
 
 USER root
 


### PR DESCRIPTION
This was previously running Docker 3.10.

This PR also changes the long-form FROM line to include image tag and digest. This ensures Dependabot is able to correctly resolve the tag from the digest.