### PR TITLE
PP-8695: Remove Jenkins ECS deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,14 +48,6 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
-      when {
-        branch 'master'
-      }
-      steps {
-        deployEcs("notifications")
-      }
-    }
     //stage('Smoke Tests') {
     //  when {
     //    branch 'master'


### PR DESCRIPTION
Remove Jenkins ECS Deploy step, it was deploying to a service with 0 tasks running which we have now removed

