### PR TITLE
PP-8696: Remove unneeded stage from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,14 +48,6 @@ pipeline {
         }
       }
     }
-    //stage('Smoke Tests') {
-    //  when {
-    //    branch 'master'
-    //  }
-    //  steps {
-    //    runDirectDebitSmokeTest()
-    //  }
-    //}
     stage('Complete') {
       failFast true
       parallel {


### PR DESCRIPTION
Given Jenkins doesn't do deployment anymore, this stage isn't needed.