### PR TITLE
PP-9376 Split release workflow and add concurrency

### DIFF
--- a/.github/workflows/build-notifications-image.yml
+++ b/.github/workflows/build-notifications-image.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - master
 
+concurrency: notifications-post-merge
+
 jobs:
   test:
     uses: ./.github/workflows/run-tests.yml

--- a/.github/workflows/build-notifications-image.yml
+++ b/.github/workflows/build-notifications-image.yml
@@ -5,33 +5,15 @@ env:
   AWS_REGION: eu-west-1
 
 on:
-  pull_request:
   push:
     branches:
       - master
 
 jobs:
   test:
-    name: Test Notifications
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-        with:
-          fetch-depth: '0'
-
-      - name: Build Docker Compose Stack...
-        run: |
-          cd ${GITHUB_WORKSPACE}/tests
-          docker-compose build
-
-      - name: Run Notifications Image Test
-        run: |
-          cd ${GITHUB_WORKSPACE}/tests
-          docker-compose up --abort-on-container-exit --exit-code-from tester tester
+    uses: ./.github/workflows/run-tests.yml
 
   release:
-    if: github.ref == 'refs/heads/master'
     needs: test
     name: Release
     permissions:

--- a/.github/workflows/build-notifications-image.yml
+++ b/.github/workflows/build-notifications-image.yml
@@ -1,9 +1,5 @@
 name: Build Notifications Docker Image
 
-env:
-  IMAGE_NAME: notifications
-  AWS_REGION: eu-west-1
-
 on:
   push:
     branches:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,4 +1,4 @@
-name: Build Notifications Docker Image
+name: Post Merge
 
 on:
   push:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,29 @@
+name: Test Notifications Docker Image
+
+env:
+  IMAGE_NAME: notifications
+  AWS_REGION: eu-west-1
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  test:
+    name: Test Notifications
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          fetch-depth: '0'
+
+      - name: Build Docker Compose Stack...
+        run: |
+          cd ${GITHUB_WORKSPACE}/tests
+          docker-compose build
+
+      - name: Run Notifications Image Test
+        run: |
+          cd ${GITHUB_WORKSPACE}/tests
+          docker-compose up --abort-on-container-exit --exit-code-from tester tester

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,5 @@
 name: Test Notifications Docker Image
 
-env:
-  IMAGE_NAME: notifications
-  AWS_REGION: eu-west-1
-
 on:
   pull_request:
   workflow_call:


### PR DESCRIPTION
- Splits the single workflow into run-tests and post-merge release
- Adds concurrency to limit the post-merge workflow runs to one-at-a-time ([see pay-stubs for naming convention](https://github.com/alphagov/pay-stubs/commit/ab8ad7ca24e5d2cc4168055d8d16325d87bfb685).