### PR TITLE
BAU - Whitelist rules for Stripe notifications & bump nginx module versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1ac
 
 USER root
 
-RUN ["apk", "--no-cache", "add", "openssl", "tini", "nginx=1.20.2-r2", "nginx-mod-http-naxsi=1.20.2-r2", "nginx-mod-http-xslt-filter=1.20.2-r2", "nginx-mod-http-geoip=1.20.2-r2"]
+RUN ["apk", "--no-cache", "add", "openssl", "tini", "nginx=1.22.0-r0", "nginx-mod-http-naxsi=1.22.0-r0", "nginx-mod-http-xslt-filter=1.22.0-r0", "nginx-mod-http-geoip=1.22.0-r0"]
 
 RUN ["install", "-d", "/etc/nginx/ssl"]
 

--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -28,7 +28,7 @@ BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,10
 BasicRule wl:1002 "mz:$URL:/v1/api/notifications/stripe|BODY"; # do not apply possible hex encoding check to any field
 
 # Whitelist rules for common characters for all body fields
-BasicRule wl:1000,1005,1008,1010,1011,1013,1015,1016,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/stripe|BODY";
+BasicRule wl:1000,1001,1005,1008,1010,1011,1013,1015,1016,1101,1200,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/stripe|BODY";
 
 # Whitelist all characters we allow for descriptions in public-api for description field
 BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^description";


### PR DESCRIPTION
## WHAT
- Noticed that stripe notifications are blocked on below rules (for last 7 days) which will impact payment journey.

1001 - double quote (postal_code - example YO32 \"rh)
1101 - https scheme (https://support.stripe.com/ in message)
1200 - double dot (city field - example: lancing.. west sussex)

- Also bumps nginx modules to the latest version