### PR TITLE
PP-10877-apk-upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,25 @@
 FROM alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 
+RUN apk -U upgrade --available
+
 USER root
 
-RUN ["apk", "--no-cache", "add", "openssl", "tini", "nginx=1.24.0-r6", "nginx-mod-http-naxsi=1.24.0-r6", "nginx-mod-http-xslt-filter=1.24.0-r6", "nginx-mod-http-geoip=1.24.0-r6"]
+RUN apk --no-cache add \
+    openssl \
+    tini \
+    nginx=1.24.0-r7 \
+    nginx-mod-http-naxsi=1.24.0-r7 \
+    nginx-mod-http-xslt-filter=1.24.0-r7 \
+    nginx-mod-http-geoip=1.24.0-r7
 
-RUN ["install", "-d", "/etc/nginx/ssl"]
+RUN install -d /etc/nginx/ssl
 
+# forward request and error logs to docker log collector
 RUN openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048 &>/dev/null \
-    # forward request and error logs to docker log collector
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-RUN ["install", "-d", "/app"]
+RUN install -d /app
 COPY src/docker-startup.sh /app
 COPY src/files/naxsi*.rules /etc/nginx/
 COPY src/files/authorized_ip /etc/nginx/


### PR DESCRIPTION
Update Alpine when Docker container is built.

The Dockerfile I checked out could not build due to package version pinning. I fixed it by bumping the version of the nginx packages from r6 to r7. 

`tests/docker-test-local.sh` passes.