### PR TITLE
PP-11316-replace-default-page-with-redirect

### DIFF
--- a/src/files/sites.nginx
+++ b/src/files/sites.nginx
@@ -26,6 +26,12 @@ server {
   ssl_certificate /etc/keys/crt;
   ssl_certificate_key /etc/keys/key;
 
+  location ~ ^/$ {
+    return 301 https://payments.service.gov.uk/;
+  }
+
+  error_page 404 https://gov.uk/404;
+
   # Health check url
   location /healthcheck {
     set $http_x_request_id $request_id;

--- a/tests/notifications-test.js
+++ b/tests/notifications-test.js
@@ -5,6 +5,7 @@ const https = require('https')
 
 // This is the list of paths to test and the expected HTTP Status for each...
 const testsToRun = [
+    { path: '/', expectedStatus: 301 },
     { path: '/healthcheck', expectedStatus: 200 },
     { path: '/request-denied', expectedStatus: 400 },
     { path: '/v1/api/notifications/epdq', expectedStatus: 200 },
@@ -15,7 +16,7 @@ const testsToRun = [
     { path: '/v1/api/notifications/epdq?q="><script>alert(0)</script>', expectedStatus: 400 },
     { path: '/v1/api/notifications/worldpay?a=SELECT%20FROM%20users%3B%20%26%26', expectedStatus: 400 },
     { path: '/v1/api/notifications/worldpay?a=SELECT%20FROM%20users;&&', expectedStatus: 400 },
-    { path: '/invalid/path', expectedStatus: 404 },
+    { path: '/invalid/path', expectedStatus: 302 },
 ]
 
 async function testNotificationPath(path, expectedStatus = 200) {


### PR DESCRIPTION
## What

Replace the default nginx placeholder pages with redirects to existing pages. Hitting the root of the service now sends you to https://payments.service.gov.uk/, and requesting a non-existent page sends you to https://gov.uk/404.

## How
/ sends a 301. 404 uses the default nginx redirect method, which sends the user a 302. If you follow the 302, gov.uk will serve up a 404, but if you take it at face value -- like the tests do -- you get the 302. If this is not acceptable, please flag it now!