### PR TITLE
PP-12614: Allow equals and double encoding in body fields

### DIFF
--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -17,18 +17,12 @@ BasicRule wl:1205 "mz:BODY";
 # SQL key words, 0x, \\ in cookie
 BasicRule wl:1000,1002,1007 "mz:$HEADERS_VAR:cookie";
 
-# SMARTPAY NOTIFICATIONS - whitelist rules we have blocked on for all body fields
-BasicRule wl:1000,1001,1005,1007,1008,1009,1010,1011,1013,1015,1016,1200,1205,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/smartpay|BODY";
-
-# EPDQ NOTIFICATIONS - cn field in ePDQ notifications is cardholder name - match what we allow in frontend
-BasicRule wl:1000,1001,1005,1008,1009,1010,1011,1013,1015,1016,1200,1205,1302,1303,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/epdq|$BODY_VAR_X:^cn$";
-
 # STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
 BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix
 BasicRule wl:1002 "mz:$URL:/v1/api/notifications/stripe|BODY"; # do not apply possible hex encoding check to any field
 
 # Whitelist rules for common characters for all body fields
-BasicRule wl:1000,1001,1005,1008,1010,1011,1013,1015,1016,1101,1200,1310,1311,1312,1314 "mz:$URL:/v1/api/notifications/stripe|BODY";
+BasicRule wl:1000,1001,1005,1008,1009,1010,1011,1013,1015,1016,1101,1200,1310,1311,1312,1314,1315 "mz:$URL:/v1/api/notifications/stripe|BODY";
 
 # Whitelist all characters we allow for descriptions in public-api for description field
 BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^description";


### PR DESCRIPTION
1. Remove rules for endpoints for past suppliers
2. Allow a couple of extra rules through to avoid erroneously blocked requests