### PR TITLE
ZD-5838986 Allow /* and */ in Stripe webhook message bodies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ USER root
 RUN apk --no-cache add \
     openssl \
     tini \
-    nginx=1.26.0-r1 \
-    nginx-mod-http-naxsi=1.26.0-r1 \
-    nginx-mod-http-xslt-filter=1.26.0-r1 \
-    nginx-mod-http-geoip=1.26.0-r1
+    nginx=1.26.0-r2 \
+    nginx-mod-http-naxsi=1.26.0-r2 \
+    nginx-mod-http-xslt-filter=1.26.0-r2 \
+    nginx-mod-http-geoip=1.26.0-r2
 
 RUN install -d /etc/nginx/ssl
 

--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -17,12 +17,14 @@ BasicRule wl:1205 "mz:BODY";
 # SQL key words, 0x, \\ in cookie
 BasicRule wl:1000,1002,1007 "mz:$HEADERS_VAR:cookie";
 
-# STRIPE NOTIFICATIONS - return_url field in stripe notifications contains https://
+# STRIPE NOTIFICATIONS
+
+# return_url field in Stripe notifications contains https://
 BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:url$"; # applies to any JSON field which ends with `url` suffix
 BasicRule wl:1002 "mz:$URL:/v1/api/notifications/stripe|BODY"; # do not apply possible hex encoding check to any field
 
-# Whitelist rules for common characters for all body fields
-BasicRule wl:1000,1001,1005,1008,1009,1010,1011,1013,1015,1016,1101,1200,1310,1311,1312,1314,1315 "mz:$URL:/v1/api/notifications/stripe|BODY";
+# Allow rules for common characters for all Stripe body fields
+BasicRule wl:1000,1001,1003,1004,1005,1008,1009,1010,1011,1013,1015,1016,1101,1200,1310,1311,1312,1314,1315 "mz:$URL:/v1/api/notifications/stripe|BODY";
 
-# Whitelist all characters we allow for descriptions in public-api for description field
+# Allow all characters we allow for descriptions in public-api for Stripe description field
 BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^description";


### PR DESCRIPTION
Allow `/*` (NAXSI rule 1003) and `*/` (NAXSI rule 1004) in Stripe webhook message bodies. It’s safe to allow these and we are receiving webhook messages that contain `/*` in the line1 parameter in the body.