### PR TITLE
ZD-5846430 Allow -- in Stripe webhook message bodies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ USER root
 RUN apk --no-cache add \
     openssl \
     tini \
-    nginx=1.26.0-r2 \
-    nginx-mod-http-naxsi=1.26.0-r2 \
-    nginx-mod-http-xslt-filter=1.26.0-r2 \
-    nginx-mod-http-geoip=1.26.0-r2
+    nginx=1.26.1-r0 \
+    nginx-mod-http-naxsi=1.26.1-r0 \
+    nginx-mod-http-xslt-filter=1.26.1-r0 \
+    nginx-mod-http-geoip=1.26.1-r0
 
 RUN install -d /etc/nginx/ssl
 

--- a/src/files/naxsi_connector_whitelist.rules
+++ b/src/files/naxsi_connector_whitelist.rules
@@ -24,7 +24,7 @@ BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,10
 BasicRule wl:1002 "mz:$URL:/v1/api/notifications/stripe|BODY"; # do not apply possible hex encoding check to any field
 
 # Allow rules for common characters for all Stripe body fields
-BasicRule wl:1000,1001,1003,1004,1005,1008,1009,1010,1011,1013,1015,1016,1101,1200,1310,1311,1312,1314,1315 "mz:$URL:/v1/api/notifications/stripe|BODY";
+BasicRule wl:1000,1001,1003,1004,1005,1007,1008,1009,1010,1011,1013,1015,1016,1101,1200,1310,1311,1312,1314,1315 "mz:$URL:/v1/api/notifications/stripe|BODY";
 
 # Allow all characters we allow for descriptions in public-api for Stripe description field
 BasicRule wl:1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1013,1015,1016,1017,1100,1101,1200,1205,1302,1303,1310,1311,1312,1314,1315,1400,1401 "mz:$URL:/v1/api/notifications/stripe|$BODY_VAR_X:^description";


### PR DESCRIPTION
Allow `--` (NAXSI rule 1007) and in Stripe webhook message bodies. It’s safe to allow and we’re receiving it in billing addresses in some notifications (presumably due to people mistyping Chorlton-cum-Hardy or similar).