### PR TITLE
PP-13582 Change logs to KV format

### DIFF
--- a/src/files/nginx_conf
+++ b/src/files/nginx_conf
@@ -29,12 +29,17 @@ http {
 	charset_types text/css text/plain text/vnd.wap.wml application/javascript application/json application/rss+xml application/xml;
 
 	# Specifies the main log format.
-	log_format main '$server_name:$server_port $http_x_request_id $http_x_forwarded_for $remote_addr $remote_user [$time_local] '
-			'"$request" $status $body_bytes_sent $request_time $http_x_forwarded_proto "$http_referer" '
-			'"$http_user_agent"';
+    log_format key-value 'server="$server_name" dest_port="$server_port" dest_ip="$server_addr" src="$remote_addr" '
+            'src_ip="$realip_remote_addr" time_local="$time_local" protocol="$server_protocol" status="$status" '
+            'bytes_out="$bytes_sent" bytes_in="$upstream_bytes_received" http_referer="$http_referer" '
+            'http_user_agent="$http_user_agent" nginx_version="$nginx_version" '
+            'http_x_forwarded_for="$http_x_forwarded_for" http_x_header="$http_x_header" '
+            'uri_query="$query_string" uri_path="$uri" http_method="$request_method" '
+            'response_time="$upstream_response_time" request_time="$request_time" '
+            'category="$sent_http_content_type" https="$https" x_request_id="$http_x_request_id"';
 
 	# Default access log.
-	access_log /var/log/nginx/access.log main;
+	access_log /var/log/nginx/access.log key-value;
 
 	# Timeout for keep-alive connections. Server will close connections after
 	# this time.


### PR DESCRIPTION
## WHAT
- Updates logs format to KV format

    new logs
    > server="notifications" dest_port="443" dest_ip="172.19.0.3" src="172.19.0.4" src_ip="172.19.0.4" time_local="13/Feb/2025:15:03:38 +0000" protocol="HTTP/1.1" status="400" bytes_out="164" bytes_in="-" http_referer="-" http_user_agent="-" nginx_version="1.26.2" http_x_forwarded_for="-" http_x_header="-" uri_query="" uri_path="/request-denied" http_method="GET" response_time="-" request_time="0.000" category="application/octet-stream" https="on" x_request_id="3cc852707bf5afbc891a511c050eb822"

    > 2025/02/13 15:03:38 [error] 17#17: *15 NAXSI_FMT: ip=172.19.0.4&server=notifications&uri=/v1/api/notifications/worldpay&vers=1.3&total_processed=7&total_blocked=3&config=block&cscore0=$SQL&score0=8&zone0=ARGS&id0=1000&var_name0=a, client: 172.19.0.4, server: notifications, request: "GET /v1/api/notifications/worldpay?a=SELECT%20FROM%20users%3B%20%26%26 HTTP/1.1", host: "notifications"

    current logs
    > notifications:443 755300c3097a2dd19b0017700e88fc95 - 172.19.0.4 - [13/Feb/2025:15:41:18 +0000] "GET /v1/api/notifications/worldpay?a=SELECT%20FROM%20users%3B%20%26%26 HTTP/1.1" 400 6 0.000 - "-" "-"

    > 2025/02/13 15:41:18 [error] 16#16: *15 NAXSI_FMT: ip=172.19.0.4&server=notifications&uri=/v1/api/notifications/worldpay&vers=1.3&total_processed=7&total_blocked=3&config=block&cscore0=$SQL&score0=8&zone0=ARGS&id0=1000&var_name0=a, client: 172.19.0.4, server: notifications, request: "GET /v1/api/notifications/worldpay?a=SELECT%20FROM%20users%3B%20%26%26 HTTP/1.1", host: "notifications"

- `uri_query`, `remote_user`, and `http_cookie` are not included in notifications logs as they are always empty
- Depends on https://github.com/alphagov/cyber-security-splunk-apps/pull/974 being installed